### PR TITLE
Add a callback function to support Node.js v8 or later

### DIFF
--- a/module.js
+++ b/module.js
@@ -86,7 +86,9 @@ module.exports = function(settings, final_callback) {
 			return;
 		}
 		
-		fs.writeFile(sessionFile, JSON.stringify(result));
+		fs.writeFile(sessionFile, JSON.stringify(result), function(err) {
+			final_callback(err);
+		});
 
 		oauth2Client.setCredentials({
 			access_token: result.access_token,


### PR DESCRIPTION
This is an extension pull request to support Node.js v10 or later.

The following error occurs when using ga-analytics with Node.js v10.

Processing without callback function of `fs.writeFile()` API used by `module.js` has been changed by upgrading Node.js.
-v6: OK, no problem
-v8: Executable and deprecated logs are output
-v10: An error occurs

Passing a callback function to the `fs.writeFile()` argument supports v10 and later.


Thank you for the wonderful ga-analytics product.